### PR TITLE
Another PR for Feature/custom variables

### DIFF
--- a/PiwikTracker.xcodeproj/project.pbxproj
+++ b/PiwikTracker.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		1FCFF0241F82C7A50038BC17 /* CustomDimension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDC917B1F1A64BB0046F506 /* CustomDimension.swift */; };
 		1FDC917F1F1A65150046F506 /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDC917D1F1A65150046F506 /* Application.swift */; };
 		1FDC91801F1A65150046F506 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDC917E1F1A65150046F506 /* Device.swift */; };
+		32033A4E201C815D007CB511 /* CustomVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32033A4D201C815D007CB511 /* CustomVariable.swift */; };
 		82A551CEC50ABB2EAD50FC4E /* Pods_PiwikTrackerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 68F0C25DEF98C13D32CC46DD /* Pods_PiwikTrackerTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -76,6 +77,7 @@
 		1FDC917B1F1A64BB0046F506 /* CustomDimension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomDimension.swift; sourceTree = "<group>"; };
 		1FDC917D1F1A65150046F506 /* Application.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Application.swift; sourceTree = "<group>"; };
 		1FDC917E1F1A65150046F506 /* Device.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
+		32033A4D201C815D007CB511 /* CustomVariable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomVariable.swift; sourceTree = "<group>"; };
 		68F0C25DEF98C13D32CC46DD /* Pods_PiwikTrackerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PiwikTrackerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F688B0F18F298B5E61552AC /* Pods-PiwikTrackerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PiwikTrackerTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PiwikTrackerTests/Pods-PiwikTrackerTests.release.xcconfig"; sourceTree = "<group>"; };
 		FD284F50B998823EAFB0CEE9 /* Pods-PiwikTrackerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PiwikTrackerTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PiwikTrackerTests/Pods-PiwikTrackerTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -160,6 +162,7 @@
 				1F6F0CD61E61E35A008170FC /* PiwikTracker.swift */,
 				1F6F0CE01E61E4F3008170FC /* URLSessionDispatcher.swift */,
 				1FDC917B1F1A64BB0046F506 /* CustomDimension.swift */,
+				32033A4D201C815D007CB511 /* CustomVariable.swift */,
 				1F38EBF71EE568D10021FBF8 /* Logger.swift */,
 				1FDC917D1F1A65150046F506 /* Application.swift */,
 				1FDC917E1F1A65150046F506 /* Device.swift */,
@@ -383,6 +386,7 @@
 				1F0A15D01E6335E900FEAE72 /* Session.swift in Sources */,
 				1F092C1A1E26B44500394B30 /* Dispatcher.swift in Sources */,
 				1F38EBF81EE568D10021FBF8 /* Logger.swift in Sources */,
+				32033A4E201C815D007CB511 /* CustomVariable.swift in Sources */,
 				1FCFF0241F82C7A50038BC17 /* CustomDimension.swift in Sources */,
 				1F7C667F1F8C096F0066CC64 /* MainThread.swift in Sources */,
 				1F80856F1E6B4B9800A61AAF /* Locale+HttpAcceptLanguage.swift in Sources */,

--- a/PiwikTracker/CustomVariable.swift
+++ b/PiwikTracker/CustomVariable.swift
@@ -4,6 +4,9 @@ import Foundation
 
 /// See Custom Variable documentation here: https://piwik.org/docs/custom-variables/
 public struct CustomVariable {
+    /// The index of the variable.
+    let index: UInt
+
     /// The name of the variable.
     let name: String
     

--- a/PiwikTracker/CustomVariable.swift
+++ b/PiwikTracker/CustomVariable.swift
@@ -1,0 +1,12 @@
+
+import Foundation
+
+
+/// See Custom Variable documentation here: https://piwik.org/docs/custom-variables/
+public struct CustomVariable {
+    /// The name of the variable.
+    let name: String
+    
+    /// The value of the variable.
+    let value: String
+}

--- a/PiwikTracker/Event.swift
+++ b/PiwikTracker/Event.swift
@@ -55,8 +55,9 @@ public struct Event {
     /// api-key: urlref
     let referer: URL?
     let screenResolution : CGSize = Device.makeCurrentDevice().screenSize
+    
     /// api-key: _cvar
-    //let customVariables: [CustomVariable]
+    let customVariables: [CustomVariable]
     
     /// Event tracking
     /// https://piwik.org/docs/event-tracking/
@@ -71,7 +72,7 @@ public struct Event {
 }
 
 extension Event {
-    public init(tracker: PiwikTracker, action: [String], url: URL? = nil, referer: URL? = nil, eventCategory: String? = nil, eventAction: String? = nil, eventName: String? = nil, eventValue: Float? = nil, customTrackingParameters: [String:String] = [:], dimensions: [CustomDimension] = []) {
+    public init(tracker: PiwikTracker, action: [String], url: URL? = nil, referer: URL? = nil, eventCategory: String? = nil, eventAction: String? = nil, eventName: String? = nil, eventValue: Float? = nil, customTrackingParameters: [String:String] = [:], dimensions: [CustomDimension] = [], variables: [CustomVariable] = []) {
         self.siteId = tracker.siteId
         self.uuid = NSUUID()
         self.visitor = tracker.visitor
@@ -88,5 +89,6 @@ extension Event {
         self.eventValue = eventValue
         self.dimensions = tracker.dimensions + dimensions
         self.customTrackingParameters = customTrackingParameters
+        self.customVariables = tracker.customVariables + variables
     }
 }

--- a/PiwikTracker/EventSerializer.swift
+++ b/PiwikTracker/EventSerializer.swift
@@ -25,8 +25,8 @@ final class EventSerializer {
 
 fileprivate extension Event {
     
-    private func cvarParameterValue() -> String {
-        var cvars: Array<String> = customVariables.enumerated().map { "\"\($0.offset + 1)\":[\"\($0.element.name)\",\"\($0.element.value)\"]" }
+    private func customVariablesParameterValue() -> String {
+        let cvars: Array<String> = customVariables.enumerated().map { "\"\($0.offset + 1)\":[\"\($0.element.name)\",\"\($0.element.value)\"]" }
         return "{\(cvars.joined(separator: ","))}"
     }
 
@@ -67,7 +67,7 @@ fileprivate extension Event {
             items += dimensions.map { URLQueryItem(name: "dimension\($0.index)", value: $0.value) }
             items += customTrackingParameters.map { return URLQueryItem(name: $0.key, value: $0.value) }
             if customVariables.count > 0 {
-                items.append( URLQueryItem(name: "_cvar", value: cvarParameterValue()) )
+                items.append( URLQueryItem(name: "_cvar", value: customVariablesParameterValue()) )
             }
 
             return items

--- a/PiwikTracker/EventSerializer.swift
+++ b/PiwikTracker/EventSerializer.swift
@@ -24,9 +24,15 @@ final class EventSerializer {
 }
 
 fileprivate extension Event {
+    
+    private func cvarParameterValue() -> String {
+        var cvars: Array<String> = customVariables.enumerated().map { "\"\($0.offset + 1)\":[\"\($0.element.name)\",\"\($0.element.value)\"]" }
+        return "{\(cvars.joined(separator: ","))}"
+    }
+
     var queryItems: [URLQueryItem] {
         get {
-            let items = [
+            var items = [
                 URLQueryItem(name: "idsite", value: siteId),
                 URLQueryItem(name: "rec", value: "1"),
                 // Visitor
@@ -57,10 +63,14 @@ fileprivate extension Event {
                 URLQueryItem(name: "e_v", value: eventValue != nil ? "\(eventValue!)" : nil),
                 
                 ].filter { $0.value != nil }
-            
-            let dimensionItems = dimensions.map { URLQueryItem(name: "dimension\($0.index)", value: $0.value) }
-            let customItems = customTrackingParameters.map { return URLQueryItem(name: $0.key, value: $0.value) }
-            return items + dimensionItems + customItems
+
+            items += dimensions.map { URLQueryItem(name: "dimension\($0.index)", value: $0.value) }
+            items += customTrackingParameters.map { return URLQueryItem(name: $0.key, value: $0.value) }
+            if customVariables.count > 0 {
+                items.append( URLQueryItem(name: "_cvar", value: cvarParameterValue()) )
+            }
+
+            return items
         }
     }
 }

--- a/PiwikTracker/EventSerializer.swift
+++ b/PiwikTracker/EventSerializer.swift
@@ -26,7 +26,7 @@ final class EventSerializer {
 fileprivate extension Event {
     
     private func customVariableParameterValue() -> String {
-        let customVariableParameterValue: Array<String> = customVariables.enumerated().map { "\"\($0.element.index)\":[\"\($0.element.name)\",\"\($0.element.value)\"]" }
+        let customVariableParameterValue: [String] = customVariables.map { "\"\($0.index)\":[\"\($0.name)\",\"\($0.value)\"]" }
         return "{\(customVariableParameterValue.joined(separator: ","))}"
     }
 

--- a/PiwikTracker/EventSerializer.swift
+++ b/PiwikTracker/EventSerializer.swift
@@ -25,14 +25,14 @@ final class EventSerializer {
 
 fileprivate extension Event {
     
-    private func customVariablesParameterValue() -> String {
-        let cvars: Array<String> = customVariables.enumerated().map { "\"\($0.offset + 1)\":[\"\($0.element.name)\",\"\($0.element.value)\"]" }
-        return "{\(cvars.joined(separator: ","))}"
+    private func customVariableParameterValue() -> String {
+        let customVariableParameterValue: Array<String> = customVariables.enumerated().map { "\"\($0.element.index)\":[\"\($0.element.name)\",\"\($0.element.value)\"]" }
+        return "{\(customVariableParameterValue.joined(separator: ","))}"
     }
 
     var queryItems: [URLQueryItem] {
         get {
-            var items = [
+            let items = [
                 URLQueryItem(name: "idsite", value: siteId),
                 URLQueryItem(name: "rec", value: "1"),
                 // Visitor
@@ -64,13 +64,11 @@ fileprivate extension Event {
                 
                 ].filter { $0.value != nil }
 
-            items += dimensions.map { URLQueryItem(name: "dimension\($0.index)", value: $0.value) }
-            items += customTrackingParameters.map { return URLQueryItem(name: $0.key, value: $0.value) }
-            if customVariables.count > 0 {
-                items.append( URLQueryItem(name: "_cvar", value: customVariablesParameterValue()) )
-            }
+            let dimensionItems = dimensions.map { URLQueryItem(name: "dimension\($0.index)", value: $0.value) }
+            let customItems = customTrackingParameters.map { return URLQueryItem(name: $0.key, value: $0.value) }
+            let customVariableItems = customVariables.count > 0 ? [URLQueryItem(name: "_cvar", value: customVariableParameterValue())] : []
 
-            return items
+            return items + dimensionItems + customItems + customVariableItems
         }
     }
 }

--- a/PiwikTracker/PiwikTracker.swift
+++ b/PiwikTracker/PiwikTracker.swift
@@ -320,17 +320,6 @@ extension PiwikTracker {
 
 
 extension PiwikTracker {
-    
-    public func getDefaultCVars() -> [CustomVariable] {
-        let currentDevice = Device.makeCurrentDevice()
-        let app = Application.makeCurrentApplication()
-        
-        return [
-            CustomVariable( index:1, name: "Platform", value: currentDevice.platform ),
-            CustomVariable( index:2, name: "OS version", value: currentDevice.osVersion ),
-            CustomVariable( index:3, name: "App version", value: app.bundleVersion ?? "unknown" )
-        ]
-    }
 
     /// Set a permanent new Custom Variable.
     ///


### PR DESCRIPTION
Hi,

This PR is the continuation of the work made by @zantoku in PR #205, which is stuck because review remarks have not yet been taken into account.

What I have done in this PR:
- merge the @zantoku's PR into the current develop branch
- take into account @brototyp's remarks except https://github.com/matomo-org/matomo-sdk-ios/pull/205#discussion_r154520261 because I have no idea how to make the string formatting in this piece of code more readable.
- remove default custom variables created by the initial `getDefaultCVars` method because indexes and names used for these custom variables look like very specific to an app. I have not seen  matomo using such default values in other SDKs. So, I have preferred to remove them and let the app set them.

This last point will require to make the `Device` struct accessible from objc in order to offer the same functionality as the initial PR. If you are ok, I will make it in another PR.